### PR TITLE
Update to microarch 0.3.0 and modernize compiler compatibility

### DIFF
--- a/kthbuild.py
+++ b/kthbuild.py
@@ -906,29 +906,53 @@ class KnuthConanFileV2(ConanFile):
         # if self.info.settings.compiler == "gcc" and (v >= "5" and v <= "12"):
         #     self.info.settings.compiler.version = "GCC [5, 12]"
 
-        if self.info.settings.compiler == "gcc":
-            if v >= "13":
-                self.info.settings.compiler.version = "GCC >= 13"
-            elif v >= "12":
-                self.info.settings.compiler.version = "GCC >= 12"
-            else:
-                self.info.settings.compiler.version = "GCC < 12"
+        # if self.info.settings.compiler == "gcc":
+        #     if v >= "15":
+        #         self.info.settings.compiler.version = "GCC >= 15"
+        #     elif v >= "14":
+        #         self.info.settings.compiler.version = "GCC >= 14"
+        #     elif v >= "13":
+        #         self.info.settings.compiler.version = "GCC >= 13"
+        #     elif v >= "12":
+        #         self.info.settings.compiler.version = "GCC >= 12"
+        #     else:
+        #         self.info.settings.compiler.version = "GCC < 12"
 
-        if self.info.settings.compiler == "clang":
-            if v >= "7" and v <= "15":
-                self.info.settings.compiler.version = "Clang [7, 15]"
-            elif v > "15":
-                self.info.settings.compiler.version = "Clang > 15"
-            else:
-                self.info.settings.compiler.version = "Clang < 7"
+        # if self.info.settings.compiler == "clang":
+        #     if v >= "20":
+        #         self.info.settings.compiler.version = "Clang >= 20"
+        #     elif v >= "19":
+        #         self.info.settings.compiler.version = "Clang >= 19"
+        #     elif v >= "18":
+        #         self.info.settings.compiler.version = "Clang >= 18"
+        #     elif v >= "17":
+        #         self.info.settings.compiler.version = "Clang >= 17"
+        #     elif v >= "16":
+        #         self.info.settings.compiler.version = "Clang >= 16"
+        #     elif v >= "15":
+        #         self.info.settings.compiler.version = "Clang >= 15"
+        #     elif v >= "14":
+        #         self.info.settings.compiler.version = "Clang >= 14"
+        #     elif v >= "13":
+        #         self.info.settings.compiler.version = "Clang >= 13"
+        #     else:
+        #         self.info.settings.compiler.version = "Clang < 13"
 
-        if self.info.settings.compiler == "apple-clang":
-            if (v >= "14" and v <= "14"):
-                self.info.settings.compiler.version = "apple-clang [14, 14]"
-            elif v > "14":
-                self.info.settings.compiler.version = "apple-clang > 14"
-            else:
-                self.info.settings.compiler.version = "apple-clang < 14"
+        # if self.info.settings.compiler == "apple-clang":
+        #     if v >= "18":
+        #         self.info.settings.compiler.version = "apple-clang >= 18"
+        #     elif v >= "17":
+        #         self.info.settings.compiler.version = "apple-clang >= 17"
+        #     elif v >= "16":
+        #         self.info.settings.compiler.version = "apple-clang >= 16"
+        #     elif v >= "15":
+        #         self.info.settings.compiler.version = "apple-clang >= 15"
+        #     elif v >= "14":
+        #         self.info.settings.compiler.version = "apple-clang >= 14"
+        #     elif v >= "13":
+        #         self.info.settings.compiler.version = "apple-clang >= 13"
+        #     else:
+        #         self.info.settings.compiler.version = "apple-clang < 13"
 
         # self.output.info(f"compatible_packages: {self.compatible_packages}")
 
@@ -957,6 +981,62 @@ class KnuthConanFileV2(ConanFile):
 
         if self.info.options.get_safe("march_strategy") is not None:
             self.info.options.march_strategy = "ANY"
+
+    def compatibility(self):
+        out = []
+
+        # GCC compatibility: newer versions can use binaries from older versions
+        if self.settings.compiler == "gcc":
+            compiler_version = str(self.settings.compiler.version)
+            if compiler_version == "15":
+                out.append({"settings": [("compiler.version", "14")]})
+                out.append({"settings": [("compiler.version", "13")]})
+            elif compiler_version == "14":
+                out.append({"settings": [("compiler.version", "13")]})
+
+        # Clang compatibility: newer versions can use binaries from older versions
+        elif self.settings.compiler == "clang":
+            compiler_version = str(self.settings.compiler.version)
+            if compiler_version == "20":
+                for v in ("19", "18", "17", "16", "15", "14", "13"):
+                    out.append({"settings": [("compiler.version", v)]})
+            elif compiler_version == "19":
+                for v in ("18", "17", "16", "15", "14", "13"):
+                    out.append({"settings": [("compiler.version", v)]})
+            elif compiler_version == "18":
+                for v in ("17", "16", "15", "14", "13"):
+                    out.append({"settings": [("compiler.version", v)]})
+            elif compiler_version == "17":
+                for v in ("16", "15", "14", "13"):
+                    out.append({"settings": [("compiler.version", v)]})
+            elif compiler_version == "16":
+                for v in ("15", "14", "13"):
+                    out.append({"settings": [("compiler.version", v)]})
+            elif compiler_version == "15":
+                for v in ("14", "13"):
+                    out.append({"settings": [("compiler.version", v)]})
+            elif compiler_version == "14":
+                out.append({"settings": [("compiler.version", "13")]})
+
+        # Apple Clang compatibility: newer versions can use binaries from older versions
+        elif self.settings.compiler == "apple-clang":
+            compiler_version = str(self.settings.compiler.version)
+            if compiler_version == "18":
+                for v in ("17", "16", "15", "14", "13"):
+                    out.append({"settings": [("compiler.version", v)]})
+            elif compiler_version == "17":
+                for v in ("16", "15", "14", "13"):
+                    out.append({"settings": [("compiler.version", v)]})
+            elif compiler_version == "16":
+                for v in ("15", "14", "13"):
+                    out.append({"settings": [("compiler.version", v)]})
+            elif compiler_version == "15":
+                for v in ("14", "13"):
+                    out.append({"settings": [("compiler.version", v)]})
+            elif compiler_version == "14":
+                out.append({"settings": [("compiler.version", "13")]})
+
+        return out
 
     # def _cmake_database(self, tc):
     #     if self.options.get_safe("db") is None:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ import platform
 __title__ = "kthbuild"
 __summary__ = "Knuth node build tools"
 __uri__ = "https://github.com/k-nuth/kthbuild"
-__version__ = "4.0.0"
+__version__ = "4.1.0"
 __author__ = "Fernando Pelliccioni"
 __email__ = "fpelliccioni@gmail.com"
 __license__ = "MIT"
@@ -26,7 +26,7 @@ install_requires = [
 ]
 
 if platform.machine() == 'x86_64':
-    install_requires.append("microarch >= 0.2.1")
+    install_requires.append("microarch >= 0.3.0")
 
 def running_in_cpt_context():
     # -e CONAN_UPLOAD="https://knuth.jfrog.io/artifactory/api/conan/knuth@True@upload_repo"


### PR DESCRIPTION
## Summary

This PR updates the project to use `microarch 0.3.0` and migrates from the legacy **information erasure** pattern in `package_id()` to the modern **`compatibility()`** method recommended by Conan 2.0.

## Changes

### 1. Dependencies
- ✅ Bump version to **4.1.0**
- ✅ Update `microarch` from **0.2.1** to **0.3.0**

### 2. Compiler Support
Now supporting:
- **GCC:** 13, 14, 15
- **Clang:** 13-20
- **Apple Clang:** 13-18

### 3. New ISA Extensions (from microarch 0.3.0)

**GCC 14 extensions:**
- AVX-VNNI-INT16, AVX10.1 (256/512-bit variants)
- SHA-512, SM3, SM4 cryptographic extensions
- APX_F (Advanced Performance Extensions)
- USERMSR (user mode MSR access)

**GCC 15 extensions:**
- AVX10.2
- AMX extensions: FP8, TF32, transpose, AVX512, MOVRS

### 4. Migration to Modern Compatibility Pattern

**Before (information erasure):**
```python
# package_id() - grouped all GCC 13+ together
if v >= "13":
    self.info.settings.compiler.version = "GCC >= 13"
```

**After (compatibility method):**
```python
# compatibility() - forward compatibility fallback
def compatibility(self):
    if compiler_version == "15":
        return [{"settings": [("compiler.version", "14")]},
                {"settings": [("compiler.version", "13")]}]
```

**Benefits:**
- ✅ Each compiler version generates its own package ID
- ✅ Newer versions can fallback to older binaries when needed
- ✅ Follows Conan 2.0 best practices
- ✅ Better cache efficiency without losing binary specificity

## Testing

Tested with GCC 15 on GitHub Actions (current CI setup).

## References

- [Conan 2.0 Binary Compatibility](https://docs.conan.io/2/reference/binary_model/custom_compatibility.html)
- [compatibility() method](https://docs.conan.io/2/reference/conanfile/methods/compatibility.html)